### PR TITLE
Add null check in VMread

### DIFF
--- a/Resources/VirtualMemory.cpp
+++ b/Resources/VirtualMemory.cpp
@@ -161,6 +161,11 @@ void VMinitialize()
 
 int VMread(uint64_t virtualAddress, word_t* value)
 {
+    // Validate the output pointer before accessing it
+    if (value == nullptr)
+    {
+        return 0;
+    }
     if (virtualAddress >= VIRTUAL_MEMORY_SIZE)
     {
         return 0;


### PR DESCRIPTION
## Summary
- verify that VMread is given a valid pointer before dereferencing

## Testing
- `g++ -std=c++11 -IResources -include Test/MemoryConstants_test1.h Resources/VirtualMemory.cpp Resources/PhysicalMemory.cpp Test/test1_write_read_all_virtual_memory.cpp -o test1 && ./test1`
- `g++ -std=c++11 -IResources -include Test/MemoryConstants_test2.h Resources/VirtualMemory.cpp Resources/PhysicalMemory.cpp Test/test2_write_one_page_twice_and_read.cpp -o test2 && ./test2`

------
https://chatgpt.com/codex/tasks/task_e_684b19e1da3c8332bf2f693822fd0c73