### PR TITLE
Add Makefile to build libVirtualMemory library

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,35 @@
+CC=g++
+CXX=g++
+RANLIB=ranlib
+AR=ar
+ARFLAGS=rcs
+
+LIBSRC=Resources/VirtualMemory.cpp Resources/PhysicalMemory.cpp
+LIBOBJ=$(LIBSRC:.cpp=.o)
+
+INCS=-IResources
+CFLAGS=-Wall -std=c++11 -g $(INCS)
+CXXFLAGS=$(CFLAGS)
+
+VMLIB=libVirtualMemory.a
+TARGETS=$(VMLIB)
+
+TAR=tar
+TARFLAGS=-cvf
+TARNAME=ex4.tar
+TARSRCS=$(LIBSRC) Makefile README.md
+
+all: $(TARGETS)
+
+$(TARGETS): $(LIBOBJ)
+	$(AR) $(ARFLAGS) $@ $^
+	$(RANLIB) $@
+
+clean:
+	$(RM) $(TARGETS) $(LIBOBJ) *~ *core
+
+depend:
+	makedepend -- $(CFLAGS) -- $(LIBSRC)
+
+tar:
+	$(TAR) $(TARFLAGS) $(TARNAME) $(TARSRCS)


### PR DESCRIPTION
## Summary
- create a Makefile for compiling VirtualMemory sources into `libVirtualMemory.a`
- include basic helper targets (clean, depend, tar)

## Testing
- `make`
- `g++ Resources/SimpleTest.cpp libVirtualMemory.a -o simple_test`
- `./simple_test`

------
https://chatgpt.com/codex/tasks/task_e_684b22288e94833292e7f2eca6f05d48